### PR TITLE
Remove TODOs from workflows.

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,11 +1,7 @@
 name: Smoke test the action
 
-# Assumes that the latest published normal version of `ref_slice` smaller
-# than 1.2.2 is 1.2.1.
-# TODO: Change the crate version in the corresponding branches `patch_change`
-# and `major_change` to 1.2.1 once new logic of choosing baseline is adapted.
-# Otherwise if new version 1.2.2 of `ref_slice` is released, the tests might
-# stop working correctly.
+# Assumes that the latest published normal version of `ref_slice` not greater
+# than 1.2.1 is 1.2.1 itself.
 
 on:
   workflow_call:

--- a/.github/workflows/test-cache.yml
+++ b/.github/workflows/test-cache.yml
@@ -1,11 +1,7 @@
 name: Test rustdoc caching
 
-# Assumes that the latest published normal version of `ref_slice` smaller
-# than 1.2.2 is 1.2.1.
-# TODO: Change the crate version in the corresponding branches `patch_change`
-# and `major_change` to 1.2.1 once new logic of choosing baseline is adapted.
-# Otherwise if new version 1.2.2 of `ref_slice` is released, the tests might
-# stop working correctly.
+# Assumes that the latest published normal version of `ref_slice` not greater
+# than 1.2.1 is 1.2.1 itself.
 
 on:
   workflow_call:

--- a/.github/workflows/test-inputs.yml
+++ b/.github/workflows/test-inputs.yml
@@ -1,11 +1,7 @@
 name: Test action inputs
 
-# Assumes that the latest published normal version of `ref_slice` smaller
-# than 1.2.2 is 1.2.1.
-# TODO: Change the crate version in the corresponding branches `patch_change`
-# and `major_change` to 1.2.1 once new logic of choosing baseline is adapted.
-# Otherwise if new version 1.2.2 of `ref_slice` is released, the tests might
-# stop working correctly.
+# Assumes that the latest published normal version of `ref_slice` not greater
+# than 1.2.1 is 1.2.1 itself.
 
 on:
   workflow_call:


### PR DESCRIPTION
Of course I still have to make corresponding changes in https://github.com/mgr0dzicki/cargo-semver-action-ref-slice.

But first, I wanted to ask to be 100% sure. @obi1kenobi, since `v2` using baseline choosing logic of `cargo-semver-checks` is merged into main, we can safely change the version in tests from `1.2.2` to `1.2.1`, can't we?