### PR TITLE
Update cache keys in `test-inputs.yml`

### DIFF
--- a/.github/workflows/test-inputs.yml
+++ b/.github/workflows/test-inputs.yml
@@ -286,9 +286,9 @@ jobs:
           path: ${{ github.workspace }}/semver-checks/target/semver-checks/cache
           fail-on-cache-miss: true
           lookup-only: true
-          key: -${{ github.job }}
+          key: semver-${{ github.job }}
           restore-keys: |
-            -${{ github.job }}
+            semver-${{ github.job }}
       - name: Fail if the toolchain used by the action is invalid
         if: ${{ ! contains(steps.get-cache-key.outputs.cache-matched-key, 'nightly') }}
         run: |
@@ -329,9 +329,9 @@ jobs:
           path: ${{ github.workspace }}/semver-checks/target/semver-checks/cache
           fail-on-cache-miss: true
           lookup-only: true
-          key: -${{ github.job }}
+          key: semver-${{ github.job }}
           restore-keys: |
-            -${{ github.job }}
+            semver-${{ github.job }}
       - name: Fail if the toolchain used by the action is invalid
         if: ${{ ! contains(steps.get-cache-key.outputs.cache-matched-key, 'nightly') }}
         run: |
@@ -372,9 +372,9 @@ jobs:
           path: ${{ github.workspace }}/semver-checks/target/semver-checks/cache
           fail-on-cache-miss: true
           lookup-only: true
-          key: -${{ github.job }}
+          key: semver-${{ github.job }}
           restore-keys: |
-            -${{ github.job }}
+            semver-${{ github.job }}
       - name: Fail if the toolchain used by the action is invalid
         if: ${{ ! contains(steps.get-cache-key.outputs.cache-matched-key, 'beta') }}
         run: |


### PR DESCRIPTION
It's always caching. Or DNS. This time it was caching.

A while back, we changed the default cache key prefix from empty-string to `semver` so that our cache key names don't start with a dash, since users found that confusing.

We should have updated these tests accordingly at the time, but we did not. So how did the PR with the change pass?

It used the caches from older runs of the same job which used the old names. When those caches expired and were GC'd by GitHub, the jobs started failing.

This is what broke CI for #77. This PR will fix it.