### PR TITLE
Only test stable and beta, since we aren't good about updating MSRV

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        toolchain: ["1.81", "stable", "beta"]
+        toolchain: ["stable", "beta"]
         experimental: [false]
         include:
           - os: 'ubuntu-latest'


### PR DESCRIPTION
The MSRV correctness is tested in the `cargo-semver-checks` repo itself, so there's negligible value in testing it here too.